### PR TITLE
small clamping bug fix

### DIFF
--- a/R/simulateGRC.R
+++ b/R/simulateGRC.R
@@ -639,7 +639,7 @@ if(missing(nNoise)){
     #Clamping overrides provided ICs
     if(!genIC){
       oldICs <- sracipeIC(rSet)
-      oldICs[clampedGenes == 1, ] <- t(geneClamping[, clampedGenes == 1, drop = FALSE])
+      oldICs[clampedGenes == 1, ] <- t(geneClamping)
       sracipeIC(rSet) <- oldICs
     }
 


### PR DESCRIPTION
Previous IC override took from geneClamping based on a logical where clampedGenes. But clampedGenes comes from the column names of geneClamping - i.e., the method expects geneClamping to already only include clamped genes. This causes a crash when overriding ICs because it asks for columns that don't exist. 